### PR TITLE
Improve documentation with comprehensive docstrings

### DIFF
--- a/protax/__init__.py
+++ b/protax/__init__.py
@@ -1,1 +1,19 @@
+"""
+PROTAX-GPU: A GPU-accelerated probabilistic taxonomic classification system for DNA barcodes.
 
+This package provides a JAX-based implementation of PROTAX with custom CUDA kernels
+for accelerated k-nearest neighbor search. It enables fast and accurate taxonomic
+classification of query sequences against large reference databases.
+
+Main modules:
+    - classify: Functions for classifying query sequences
+    - model: Core probabilistic model and computation functions
+    - taxonomy: Data structures for taxonomic trees and model parameters
+    - protax_utils: Utilities for reading/writing model files and sequences
+    - baseline: Simple nearest-neighbor baseline classifier
+    - ops: Custom JAX operations including GPU-accelerated KNN
+
+Example:
+    >>> from protax.classify import classify_file
+    >>> classify_file("query.aln", "model.npz", "taxonomy.npz")
+"""

--- a/protax/baseline.py
+++ b/protax/baseline.py
@@ -1,3 +1,14 @@
+"""
+Baseline nearest-neighbor classifier for PROTAX-GPU.
+
+This module provides a simple distance-based baseline classifier that assigns
+queries to the taxonomic node of their nearest reference sequence. It serves
+as a baseline for comparison with the full probabilistic PROTAX model.
+
+Note:
+    This implementation currently selects the most DISTANT reference (argmax
+    instead of argmin), which appears to be a bug. Use with caution.
+"""
 import jax
 import jax.numpy as jnp
 from protax_utils import read_baseline, read_query
@@ -11,17 +22,24 @@ def seq_dist(q, seqs, ok, ok_query):
     """
     Compute distance between one query and many references (baseline NN).
 
-    Distance is defined as 1 - matches/valid where `valid` counts positions
-    that are valid in both query and reference.
+    Distance is defined as 1 - (matches / valid) where `valid` counts positions
+    that are valid in both query and reference. Uses packed bits for efficiency.
 
     Args:
-        q: Packed bits for the query bases.
-        seqs: Packed bits for reference bases, shape (R, D').
-        ok: Packed bits mask for valid reference positions, shape (R, D').
-        ok_query: Packed bits mask for valid query positions, shape (D',).
+        q (jax.Array): Packed bits for the query bases (A/T/G/C).
+        seqs (jax.Array): Packed bits for reference bases, shape (R, D')
+            where R is number of references.
+        ok (jax.Array): Packed bits mask for valid reference positions, shape (R, D').
+        ok_query (jax.Array): Packed bits mask for valid query positions, shape (D',).
 
     Returns:
-        Index of the reference with maximum distance (largest dissimilarity).
+        jax.Array: Scalar integer index of the reference with MAXIMUM distance
+            (largest dissimilarity).
+
+    Warning:
+        This function returns argmax (most distant) instead of argmin (nearest).
+        This appears to be a bug and should be corrected for true nearest-neighbor
+        classification.
     """
 
     # count matches and valid positions
@@ -36,18 +54,26 @@ def nearest_classifier(q, seqs, ok, ok_query, n2s):
     """
     Return the leaf node id for the reference selected by `seq_dist`.
 
-    Note: As implemented, `seq_dist` returns the farthest reference (argmax
-    of distance), so this does not perform true nearest-neighbor classification.
+    This classifier assigns the query to the taxonomic node of the selected
+    reference sequence. The reference is chosen by `seq_dist`, which currently
+    returns the MOST distant reference due to a bug.
 
     Args:
-        q: Packed query bases.
-        seqs: Packed reference bases.
-        ok: Packed valid positions for references.
-        ok_query: Packed valid positions for query.
-        n2s: Sparse node-to-sequence mapping (CSC) for dereferencing leaf id.
+        q (jax.Array): Packed query bases (A/T/G/C).
+        seqs (jax.Array): Packed reference bases for all references.
+        ok (jax.Array): Packed valid positions for references.
+        ok_query (jax.Array): Packed valid positions for query.
+        n2s (scipy.sparse.csc_matrix): Sparse node-to-sequence mapping in CSC
+            format for dereferencing the leaf node id from reference index.
 
     Returns:
-        Integer node id of the selected reference's taxon.
+        int: Node id of the selected reference's most specific taxonomic assignment.
+
+    Warning:
+        As implemented, `seq_dist` returns the farthest reference (argmax of
+        distance), so this does NOT perform true nearest-neighbor classification.
+        The last index in n2s[:, closest_r].indices gives the finest taxonomic
+        level for that reference.
     """
     closest_r = int(seq_dist(q, seqs, ok, ok_query))
     return n2s[:, closest_r].indices[-1]
@@ -57,12 +83,31 @@ def classify_file(qdir, verbose=False):
     """
     Classify queries using a simple nearest-neighbor baseline and save results.
 
+    Reads query sequences from a FASTA-like alignment file, assigns each to
+    the taxonomic path of its nearest (or actually farthest, due to bug)
+    reference, and writes results to CSV.
+
     Args:
-        qdir: Path to query alignment file (two-line records).
-        verbose: Unused; reserved for future logging.
+        qdir (str or Path): Path to query alignment file containing two-line
+            records (header, sequence).
+        verbose (bool, optional): Unused; reserved for future logging.
+            Defaults to False.
+
+    Returns:
+        None
 
     Side Effects:
-        Writes `dist_baseline_results.csv` with predicted leaf paths per query.
+        Writes `dist_baseline_results.csv` with one row per query containing
+        the taxonomic path (node IDs at each level) of the selected reference.
+        Prints total classification time to stdout.
+
+    Note:
+        Model directory is currently hardcoded to "/home/roy/Documents/PROTAX-dsets/30k_small".
+        This should be parameterized for general use.
+
+    Example:
+        >>> classify_file("queries.aln")
+        finished in 5.67s
     """
 
     refs, ok_pos, n2s, paths = read_baseline(r"/home/roy/Documents/PROTAX-dsets/30k_small")

--- a/protax/baseline.py
+++ b/protax/baseline.py
@@ -9,8 +9,19 @@ import pandas as pd
 @jax.jit
 def seq_dist(q, seqs, ok, ok_query):
     """
-    Computes sequence distance between the query and 
-    an array of reference sequences
+    Compute distance between one query and many references (baseline NN).
+
+    Distance is defined as 1 - matches/valid where `valid` counts positions
+    that are valid in both query and reference.
+
+    Args:
+        q: Packed bits for the query bases.
+        seqs: Packed bits for reference bases, shape (R, D').
+        ok: Packed bits mask for valid reference positions, shape (R, D').
+        ok_query: Packed bits mask for valid query positions, shape (D',).
+
+    Returns:
+        Index of the reference with maximum distance (largest dissimilarity).
     """
 
     # count matches and valid positions
@@ -22,13 +33,36 @@ def seq_dist(q, seqs, ok, ok_query):
     return jnp.argmax(1 - (match_tots / ok))
 
 def nearest_classifier(q, seqs, ok, ok_query, n2s):
+    """
+    Return the leaf node id for the reference selected by `seq_dist`.
+
+    Note: As implemented, `seq_dist` returns the farthest reference (argmax
+    of distance), so this does not perform true nearest-neighbor classification.
+
+    Args:
+        q: Packed query bases.
+        seqs: Packed reference bases.
+        ok: Packed valid positions for references.
+        ok_query: Packed valid positions for query.
+        n2s: Sparse node-to-sequence mapping (CSC) for dereferencing leaf id.
+
+    Returns:
+        Integer node id of the selected reference's taxon.
+    """
     closest_r = int(seq_dist(q, seqs, ok, ok_query))
     return n2s[:, closest_r].indices[-1]
 
 
 def classify_file(qdir, verbose=False):
     """
-    Process a batch of queries using baseline classifier
+    Classify queries using a simple nearest-neighbor baseline and save results.
+
+    Args:
+        qdir: Path to query alignment file (two-line records).
+        verbose: Unused; reserved for future logging.
+
+    Side Effects:
+        Writes `dist_baseline_results.csv` with predicted leaf paths per query.
     """
 
     refs, ok_pos, n2s, paths = read_baseline(r"/home/roy/Documents/PROTAX-dsets/30k_small")

--- a/protax/classify.py
+++ b/protax/classify.py
@@ -1,3 +1,10 @@
+"""
+Classification module for PROTAX-GPU.
+
+This module provides functions for classifying DNA barcode sequences using trained
+PROTAX models. It includes utilities for batch classification from FASTA-like files
+and helper functions for taxonomy validation.
+"""
 import os
 
 from .protax_utils import read_model_jax, read_query, read_baseline
@@ -16,13 +23,22 @@ def load_layer(tdir):
     """
     Load per-node taxonomic levels from a taxonomy NPZ file.
 
+    This function extracts the layer/rank information for each node in the taxonomic
+    tree, where layer 0 is typically the root and higher layers represent finer
+    taxonomic ranks (e.g., kingdom, phylum, class, order, family, genus, species).
+
     Args:
-        tdir: Path-like object or string pointing to a taxonomy `.npz` file
-            produced by `convert_taxonomy` (e.g., `models/ref_db/taxonomy*.npz`).
+        tdir (str or Path): Path-like object or string pointing to a taxonomy `.npz`
+            file produced by `convert_taxonomy` (e.g., `models/ref_db/taxonomy*.npz`).
 
     Returns:
-        A 1D numpy array of integers where each entry is the layer index
-        (rank depth) for the corresponding node in the taxonomy.
+        numpy.ndarray: A 1D numpy array of integers where each entry is the layer
+            index (rank depth) for the corresponding node in the taxonomy.
+
+    Example:
+        >>> layers = load_layer("models/ref_db/taxonomy37k.npz")
+        >>> print(layers[0])  # Root node is typically at layer 0
+        0
     """
     tax_dir = Path(tdir)
 
@@ -39,14 +55,21 @@ def read_names(tdir):
     Read the taxon names from a PROTAX taxonomy text file.
 
     The file is expected to be a tab-separated text file where each line
-    contains `nid, pid, lvl, name, prior, ...`. Only the `name` field is
-    collected.
+    contains fields in the format: `nid, pid, lvl, name, prior, ...`. Only
+    the `name` field is extracted and returned.
 
     Args:
-        tdir: Path to the taxonomy `.priors` text file.
+        tdir (str or Path): Path to the taxonomy `.priors` text file containing
+            node information in tab-separated format.
 
     Returns:
-        A list of strings containing the taxon names in index order.
+        list of str: A list of strings containing the taxon names in node index
+            order, where the index in the list corresponds to the node ID.
+
+    Example:
+        >>> names = read_names("models/ref_db/taxonomy.priors")
+        >>> print(names[0])  # Root taxon name
+        'root'
     """
     f = open(tdir)
     node_dat = f.readlines()
@@ -66,13 +89,25 @@ def validate_taxonomy_query(tree, query, ok_query):
     """
     Validate that the taxonomy and query dimensions match.
 
+    This function ensures that the reference sequences in the taxonomy and the
+    query sequence have compatible dimensions for distance computation. Both the
+    packed bits arrays and the validity masks must have matching lengths.
+
     Args:
-        tree: TaxTree object containing taxonomy information.
-        query: Query sequence array.
-        ok_query: Boolean array indicating valid positions in the query.
+        tree (TaxTree): TaxTree object containing taxonomy information including
+            reference sequences and validity masks.
+        query (jax.Array): Query sequence array (packed bits representation).
+        ok_query (jax.Array): Boolean array indicating valid positions in the query
+            (packed bits representation).
 
     Raises:
-        ValueError: If dimensions are incompatible.
+        ValueError: If the sequence lengths or valid position arrays are incompatible
+            between the taxonomy references and the query.
+
+    Example:
+        >>> tree, params, N, segnum = read_model_jax("model.npz", "taxonomy.npz")
+        >>> q, ok = read_query("ATGC...")
+        >>> validate_taxonomy_query(tree, q, ok)  # Raises error if incompatible
     """
     # Check the number of positions in references and query
     if tree.refs.shape[1] != query.shape[0]:
@@ -91,17 +126,34 @@ def classify_file(qdir, par_dir, tax_dir, verbose=False):
     This function streams query sequences from a FASTA-like alignment file
     (two lines per record: header then sequence), computes per-node
     probabilities with the JAX implementation, and writes the per-level
-    predictions to `pyprotax_results.csv`.
+    predictions to `pyprotax_results.csv`. The classification is based on
+    the probabilistic taxonomic model described in the PROTAX paper.
 
     Args:
-        qdir: Path to the query alignment file (e.g., `refs.aln`).
-        par_dir: Path to the model parameters `.npz` file (e.g., `models/params/model.npz`).
-        tax_dir: Path to the taxonomy `.npz` file (e.g., `models/ref_db/taxonomy*.npz`).
-        verbose: If True, prints per-record timing and optional debug info.
+        qdir (str or Path): Path to the query alignment file containing sequences
+            to classify. Expected format: two lines per record (header, then sequence).
+            Example: `refs.aln`.
+        par_dir (str or Path): Path to the model parameters `.npz` file containing
+            trained beta coefficients and scaling statistics.
+            Example: `models/params/model.npz`.
+        tax_dir (str or Path): Path to the taxonomy `.npz` file containing the
+            reference database, taxonomic tree structure, and node mappings.
+            Example: `models/ref_db/taxonomy37k.npz`.
+        verbose (bool, optional): If True, prints per-record timing and optional
+            debug information. Defaults to False.
+
+    Returns:
+        None
 
     Side Effects:
-        Writes `pyprotax_results.csv` with one row per query containing the
-        predicted level indices.
+        Writes `pyprotax_results.csv` in the current directory with one row per
+        query containing the predicted node indices at each taxonomic level.
+        Prints total classification time to stdout.
+
+    Example:
+        >>> classify_file("queries.aln", "models/params/model.npz",
+        ...               "models/ref_db/taxonomy37k.npz", verbose=True)
+        finished in 12.34s
     """
 
     tree, params, N, segnum = read_model_jax(par_dir, tax_dir)
@@ -155,18 +207,35 @@ def classify(q, ok, tree, params, segnum, N):
     """
     Classify a single query sequence given a taxonomy and model parameters.
 
-    This is a placeholder for a lower-level API that mirrors `classify_file`.
+    This is a lower-level API for single-sequence classification that can be
+    used programmatically. Currently a placeholder for future implementation.
+    Use `classify_file` for batch processing or implement custom logic using
+    `get_probs` from the model module.
 
     Args:
-        q: Packed bits representation of the query sequence bases (A/T/G/C).
-        ok: Packed bits mask of positions that are valid base calls.
-        tree: `TaxTree` containing reference database and topology.
-        params: `ProtaxModel` parameters (beta and scaling stats).
-        segnum: Number of unique segment ids in `tree.segments`.
-        N: Number of nodes in the taxonomy.
+        q (jax.Array): Packed bits representation of the query sequence bases
+            (A/T/G/C), with shape (D',) where D' is the packed width.
+        ok (jax.Array): Packed bits mask of positions that are valid base calls,
+            with shape (D',).
+        tree (TaxTree): `TaxTree` instance containing reference database and
+            taxonomic topology.
+        params (ProtaxModel): `ProtaxModel` instance with beta coefficients and
+            scaling statistics (sc_mean, sc_var).
+        segnum (int): Number of unique segment ids in `tree.segments` (used for
+            JAX segment operations).
+        N (int): Total number of nodes in the taxonomy.
 
     Returns:
-        Not implemented yet.
+        Not implemented yet. Future versions will return predicted node IDs or
+        probability distributions.
+
+    Note:
+        This function is a placeholder. For single-sequence classification, you
+        can use:
+        ```python
+        probs = get_probs(q, ok, tree, params, segnum, N)
+        classified = jnp.argmax(probs)
+        ```
     """
     pass
 

--- a/protax/classify.py
+++ b/protax/classify.py
@@ -13,6 +13,17 @@ from pathlib import Path
 
 
 def load_layer(tdir):
+    """
+    Load per-node taxonomic levels from a taxonomy NPZ file.
+
+    Args:
+        tdir: Path-like object or string pointing to a taxonomy `.npz` file
+            produced by `convert_taxonomy` (e.g., `models/ref_db/taxonomy*.npz`).
+
+    Returns:
+        A 1D numpy array of integers where each entry is the layer index
+        (rank depth) for the corresponding node in the taxonomy.
+    """
     tax_dir = Path(tdir)
 
     tax = np.load(tax_dir.resolve())
@@ -25,7 +36,17 @@ def load_layer(tdir):
 
 def read_names(tdir):
     """
-    Read names of each taxon from file
+    Read the taxon names from a PROTAX taxonomy text file.
+
+    The file is expected to be a tab-separated text file where each line
+    contains `nid, pid, lvl, name, prior, ...`. Only the `name` field is
+    collected.
+
+    Args:
+        tdir: Path to the taxonomy `.priors` text file.
+
+    Returns:
+        A list of strings containing the taxon names in index order.
     """
     f = open(tdir)
     node_dat = f.readlines()
@@ -65,7 +86,22 @@ def validate_taxonomy_query(tree, query, ok_query):
 
 def classify_file(qdir, par_dir, tax_dir, verbose=False):
     """
-    Process a batch of queries given a model and taxonomy directory
+    Classify a batch of query sequences using a trained PROTAX model.
+
+    This function streams query sequences from a FASTA-like alignment file
+    (two lines per record: header then sequence), computes per-node
+    probabilities with the JAX implementation, and writes the per-level
+    predictions to `pyprotax_results.csv`.
+
+    Args:
+        qdir: Path to the query alignment file (e.g., `refs.aln`).
+        par_dir: Path to the model parameters `.npz` file (e.g., `models/params/model.npz`).
+        tax_dir: Path to the taxonomy `.npz` file (e.g., `models/ref_db/taxonomy*.npz`).
+        verbose: If True, prints per-record timing and optional debug info.
+
+    Side Effects:
+        Writes `pyprotax_results.csv` with one row per query containing the
+        predicted level indices.
     """
 
     tree, params, N, segnum = read_model_jax(par_dir, tax_dir)
@@ -116,6 +152,22 @@ def classify_file(qdir, par_dir, tax_dir, verbose=False):
 
 
 def classify(q, ok, tree, params, segnum, N):
+    """
+    Classify a single query sequence given a taxonomy and model parameters.
+
+    This is a placeholder for a lower-level API that mirrors `classify_file`.
+
+    Args:
+        q: Packed bits representation of the query sequence bases (A/T/G/C).
+        ok: Packed bits mask of positions that are valid base calls.
+        tree: `TaxTree` containing reference database and topology.
+        params: `ProtaxModel` parameters (beta and scaling stats).
+        segnum: Number of unique segment ids in `tree.segments`.
+        N: Number of nodes in the taxonomy.
+
+    Returns:
+        Not implemented yet.
+    """
     pass
 
 

--- a/protax/model.py
+++ b/protax/model.py
@@ -1,3 +1,16 @@
+"""
+Core probabilistic model implementation for PROTAX-GPU.
+
+This module contains the main computational functions for the PROTAX probabilistic
+taxonomic classification model. It implements:
+- Sequence distance computation using packed bit operations
+- Design matrix construction with KNN-based features
+- Branch probability calculations with segment-wise normalization
+- Path probability aggregation across taxonomic levels
+
+The implementation uses JAX for automatic differentiation and GPU acceleration,
+with custom CUDA kernels for efficient k-nearest neighbor search.
+"""
 import jax
 import jax.numpy as jnp
 from jax.experimental import sparse
@@ -11,18 +24,28 @@ def seq_dist(q, seqs, ok, ok_query):
     """
     Compute Hamming-like distance between one query and many references.
 
-    Distances are computed as 1 - matches/valid where `valid` counts positions
-    that are valid in both the query and each reference. Bits are packed; A/T/G/C
-    bits are compared via bitwise operations.
+    Distances are computed as 1 - (matches / valid_positions) where valid_positions
+    counts positions that are valid (not gaps or ambiguous) in both the query and
+    each reference. Sequences are stored as packed bits for memory efficiency;
+    A/T/G/C are compared via bitwise AND operations followed by population count.
 
     Args:
-        q: Packed bits array for the query sequence bases (A/T/G/C), shape (D',).
-        seqs: Packed bits for reference sequences, shape (R, D').
-        ok: Packed bits mask of valid positions for references, shape (R, D').
-        ok_query: Packed bits mask of valid positions for the query, shape (D',).
+        q (jax.Array): Packed bits array for the query sequence bases (A/T/G/C),
+            shape (D',) where D' = ceil(4*D/8) for sequence length D.
+        seqs (jax.Array): Packed bits for reference sequences, shape (R, D')
+            where R is the number of references.
+        ok (jax.Array): Packed bits mask of valid positions for references,
+            shape (R, D').
+        ok_query (jax.Array): Packed bits mask of valid positions for the query,
+            shape (D',).
 
     Returns:
-        A 1D jax array of distances for each reference, shape (R,).
+        jax.Array: A 1D array of normalized Hamming distances for each reference,
+            shape (R,). Values range from 0 (identical) to 1 (no matches).
+
+    Note:
+        This function can be JIT-compiled with `jax.jit` for improved performance.
+        The packed bits representation uses 4 bits per nucleotide position (A/T/G/C).
     """
 
     # count matches and valid positions
@@ -36,14 +59,24 @@ def seq_dist(q, seqs, ok, ok_query):
 
 def seq_dist2(s1, s2):
     """
-    Alternative distance using explicit one-hot with validity channel.
+    Alternative distance computation using explicit one-hot encoding with validity.
+
+    This is an alternative implementation that uses a 5-channel representation
+    where channels 0-3 are one-hot encoded nucleotides (A/T/G/C) and channel 4
+    is a validity mask. Currently unused in favor of `seq_dist`.
 
     Args:
-        s1: One-hot with validity, shape (5, D) where last row is valid mask.
-        s2: One-hot with validity, shape (5, D) where last row is valid mask.
+        s1 (jax.Array): One-hot encoded sequence with validity, shape (5, D)
+            where D is sequence length and row 4 is the valid position mask.
+        s2 (jax.Array): One-hot encoded sequence with validity, shape (5, D).
 
     Returns:
-        Scalar fraction of matches over valid positions.
+        jax.Array: Scalar value representing the fraction of matching positions
+            over valid positions. Range [0, 1].
+
+    Note:
+        This function is not currently used in the main PROTAX pipeline but may
+        be useful for debugging or alternative encoding schemes.
     """
     intersect = jnp.bitwise_and(s1, s2)
     matches = jax.lax.population_count(intersect, axis=1)
@@ -57,19 +90,32 @@ def get_X(q, ok_q, tree, N, sc_mean, sc_var):
     """
     Construct the PROTAX design matrix using KNN distances and node state.
 
-    The design matrix concatenates binary node state features and KNN-derived
-    distance features normalized by per-level scaling parameters.
+    The design matrix is the input to the logistic regression model at each node.
+    It combines binary node state indicators (empty-but-known, has-refs) with
+    normalized KNN distance features. For each node, the k=2 nearest reference
+    sequences are identified and their distances are standardized using per-level
+    mean and variance statistics.
 
     Args:
-        q: Packed bits for the query sequence bases (A/T/G/C).
-        ok_q: Packed bits mask for valid query positions.
-        tree: `TaxTree` instance with references, node2seq, and node_state.
-        N: Number of taxonomy nodes.
-        sc_mean: (N, 2) scaling means per node and distance column.
-        sc_var: (N, 2) scaling variances per node and distance column.
+        q (jax.Array): Packed bits for the query sequence bases (A/T/G/C).
+        ok_q (jax.Array): Packed bits mask for valid query positions.
+        tree (TaxTree): `TaxTree` instance containing references, node-to-sequence
+            mapping (node2seq), and node state indicators.
+        N (int): Number of taxonomy nodes.
+        sc_mean (jax.Array): Per-node scaling means for distance features,
+            shape (N, 2) for k=2 nearest neighbors.
+        sc_var (jax.Array): Per-node scaling variances for distance features,
+            shape (N, 2).
 
     Returns:
-        A jax array of shape (N, M) where M = node_state_cols + 2.
+        jax.Array: Design matrix of shape (N, M) where M = 2 (node_state) + 2 (knn).
+            Column 0: empty-but-known indicator
+            Column 1: has-references indicator
+            Columns 2-3: Standardized distances to k=2 nearest references
+
+    Note:
+        Nodes without references will have their KNN features masked to zero
+        via multiplication by node_state[:, 1].
     """
 
     node2seq = tree.node2seq
@@ -87,14 +133,22 @@ def get_X(q, ok_q, tree, N, sc_mean, sc_var):
 
 def get_z(X, params):
     """
-    Compute per-node linear score z = X · beta.
+    Compute per-node linear score z = X · beta (element-wise product then sum).
+
+    This computes the logit for each node in the taxonomic tree by taking the
+    element-wise product of the design matrix and parameter matrix, then summing
+    across features. This is equivalent to a dot product per row.
 
     Args:
-        X: Design matrix of shape (N, M).
-        params: `ProtaxModel` containing `beta` with shape (N, M).
+        X (jax.Array): Design matrix of shape (N, M) where N is number of nodes
+            and M is number of features.
+        params (ProtaxModel): `ProtaxModel` instance containing `beta` with
+            shape (N, M) - per-node regression coefficients.
 
     Returns:
-        A 1D jax array z of length N.
+        jax.Array: A 1D array z of length N containing the linear score for
+            each node. These scores are converted to probabilities via softmax
+            within each parent segment.
     """
     z = jnp.sum(jnp.multiply(X, params.beta), axis=1)
     return z
@@ -102,15 +156,25 @@ def get_z(X, params):
 
 def get_bprobs(z, segments, segnum):
     """
-    Compute normalized branch probabilities per parent segment.
+    Compute normalized branch probabilities per parent segment using softmax.
+
+    For each parent node, this function normalizes the scores of its children
+    to sum to 1, creating a categorical distribution over child nodes. This
+    implements the conditional probability P(child | parent) in the PROTAX model.
 
     Args:
-        z: Nonnegative scores per node, shape (N,).
-        segments: Segment id (parent id bucket) per node, shape (N,).
-        segnum: Number of unique segment ids.
+        z (jax.Array): Nonnegative scores per node, shape (N,). Typically
+            exp(linear_score) or exp(linear_score) * prior.
+        segments (jax.Array): Segment id (parent id bucket) per node, shape (N,).
+            Nodes with the same segment id share a parent and compete for probability.
+        segnum (int): Number of unique segment ids (number of parents + 1 for root).
 
     Returns:
-        A jax array of branch probabilities per node, shape (N,).
+        jax.Array: Branch probabilities per node, shape (N,). Values sum to 1
+            within each segment. Root node (index 0) is set to probability 1.
+
+    Note:
+        NaN values (from 0/0 for empty segments) are replaced with 0.
     """
     norm_factors = jax.ops.segment_sum(z, segments, num_segments=segnum, indices_are_sorted=True)
     norm_factors = jnp.take(norm_factors, segments, indices_are_sorted=True)
@@ -125,15 +189,25 @@ def get_log_bprobs(z, segments, segnum):
     """
     Compute log-branch probabilities per node in a numerically stable way.
 
-    Useful for training and for accumulating log-probabilities along paths.
+    This implements log-softmax normalization within each parent segment, which
+    is numerically more stable than computing probabilities then taking logs.
+    Useful for training (gradient descent) and for accumulating log-probabilities
+    along taxonomic paths.
 
     Args:
-        z: Real-valued scores per node, shape (N,).
-        segments: Segment id (parent id bucket) per node, shape (N,).
-        segnum: Number of unique segment ids.
+        z (jax.Array): Real-valued scores (logits) per node, shape (N,).
+            Can be any real number, not necessarily non-negative.
+        segments (jax.Array): Segment id (parent id bucket) per node, shape (N,).
+        segnum (int): Number of unique segment ids.
 
     Returns:
-        A jax array of log-branch probabilities per node, shape (N,).
+        jax.Array: Log-branch probabilities per node, shape (N,).
+            Values are <= 0, and exp(values) sum to 1 within each segment.
+            Root node (index 0) is set to log(1) = 0.
+
+    Note:
+        This function implements: log(exp(z_i) / sum_j(exp(z_j))) = z_i - log(sum_j(exp(z_j)))
+        NaN values from empty segments are replaced with 0.
     """
 
     exp_z = jnp.exp(z)
@@ -149,15 +223,27 @@ def fill_bprob(X, beta, tree, segnum):
     """
     Compute per-level path-wise branch probabilities across the taxonomy.
 
+    This function computes the branch probability for each node, then organizes
+    them into a matrix indexed by [level, node] for efficient path probability
+    computation. The scores are combined with prior probabilities and normalized
+    within segments using numerically stable operations.
+
     Args:
-        X: Design matrix, shape (N, M).
-        beta: Parameter matrix, shape (N, M).
-        tree: `TaxTree` with segments, paths, node_state, and priors.
-        segnum: Number of unique segment ids.
+        X (jax.Array): Design matrix, shape (N, M) where N is nodes, M is features.
+        beta (jax.Array): Parameter matrix, shape (N, M) containing regression
+            coefficients for each node.
+        tree (TaxTree): `TaxTree` instance with segments, paths, node_state, and
+            prior probability mass per node.
+        segnum (int): Number of unique segment ids for segment operations.
 
     Returns:
-        A jax array of shape (L, P) with per-level branch probabilities along
-        each path in `tree.paths` (L levels by P paths).
+        jax.Array: Shape (L, P) with per-level branch probabilities along each
+            path in `tree.paths`, where L is number of levels and P is number of
+            nodes. Missing entries (invalid paths) are filled with 1.
+
+    Note:
+        Uses log-sum-exp trick (max subtraction) for numerical stability before
+        exponentiating and normalizing within segments.
     """
     z = jnp.sum(jnp.multiply(X, beta), axis=1)
     max_z = jax.ops.segment_max(z, tree.segments, num_segments=segnum, indices_are_sorted=True)
@@ -174,15 +260,22 @@ def fill_log_bprob(X, beta, tree, segnum):
     """
     Compute per-level log-branch probabilities across the taxonomy.
 
+    Similar to `fill_bprob` but works in log-space for numerical stability.
+    This is the preferred version for training and for computing log-likelihood.
+
     Args:
-        X: Design matrix, shape (N, M).
-        beta: Parameter matrix, shape (N, M).
-        tree: `TaxTree` with segments and paths.
-        segnum: Number of unique segment ids.
+        X (jax.Array): Design matrix, shape (N, M).
+        beta (jax.Array): Parameter matrix, shape (N, M).
+        tree (TaxTree): `TaxTree` instance with segments and paths.
+        segnum (int): Number of unique segment ids.
 
     Returns:
-        A jax array of shape (L, P) with per-level log-branch probabilities
-        along each path in `tree.paths`.
+        jax.Array: Shape (L, P) with per-level log-branch probabilities along
+            each path in `tree.paths`. Missing entries are filled with log(1) = 0.
+
+    Note:
+        Log-space arithmetic is used throughout to avoid numerical underflow when
+        computing products of many small probabilities along deep taxonomic paths.
     """
     z = jnp.sum(jnp.multiply(X, beta), axis=1)
     max_z = jax.ops.segment_max(z, tree.segments, num_segments=segnum, indices_are_sorted=True)
@@ -199,18 +292,29 @@ def fill_log_bprob(X, beta, tree, segnum):
 # @partial(jax.jit, static_argnums=(4, 5))
 def get_log_probs(q, ok, tree, params, segnum, N):
     """
-    Compute log-probability of each node by summing log-branch probs per path.
+    Compute log-probability of each node by summing log-branch probs along paths.
+
+    This is the main inference function in log-space. It computes the total
+    log-probability of each node in the taxonomy by:
+    1. Building the design matrix X from query-reference distances
+    2. Computing log-branch probabilities for each node
+    3. Summing log-probabilities along paths from root to each node
 
     Args:
-        q: Packed bits for query bases.
-        ok: Packed bits mask for valid query positions.
-        tree: `TaxTree` instance.
-        params: `ProtaxModel` with beta, sc_mean, sc_var.
-        segnum: Number of unique segment ids.
-        N: Number of nodes in the taxonomy.
+        q (jax.Array): Packed bits for query bases.
+        ok (jax.Array): Packed bits mask for valid query positions.
+        tree (TaxTree): `TaxTree` instance with taxonomy structure.
+        params (ProtaxModel): `ProtaxModel` with beta, sc_mean, sc_var.
+        segnum (int): Number of unique segment ids (for JIT compilation).
+        N (int): Number of nodes in the taxonomy (for JIT compilation).
 
     Returns:
-        A 1D jax array of length N with total log-probabilities per node.
+        jax.Array: A 1D array of length N with total log-probabilities per node.
+            These are log P(node | query), unnormalized across levels.
+
+    Note:
+        Can be JIT-compiled by uncommenting the decorator. Static arguments
+        (segnum, N) must be known at compile time.
     """
     X = get_X(q, ok, tree, N, params.sc_mean, params.sc_var)
     bprobs = fill_log_bprob(X, params.beta, tree, segnum)
@@ -219,18 +323,30 @@ def get_log_probs(q, ok, tree, params, segnum, N):
 # @partial(jax.jit, static_argnums=(4, 5))
 def get_probs(q, ok, tree, params, segnum, N):
     """
-    Compute probability of each node by multiplying branch probs per path.
+    Compute probability of each node by multiplying branch probs along paths.
+
+    This is the main inference function in probability space (not log-space).
+    It computes the total probability of each node in the taxonomy by:
+    1. Building the design matrix X from query-reference distances
+    2. Computing branch probabilities for each node
+    3. Multiplying probabilities along paths from root to each node
 
     Args:
-        q: Packed bits for query bases.
-        ok: Packed bits mask for valid query positions.
-        tree: `TaxTree` instance.
-        params: `ProtaxModel` with beta, sc_mean, sc_var.
-        segnum: Number of unique segment ids.
-        N: Number of nodes in the taxonomy.
+        q (jax.Array): Packed bits for query bases.
+        ok (jax.Array): Packed bits mask for valid query positions.
+        tree (TaxTree): `TaxTree` instance with taxonomy structure.
+        params (ProtaxModel): `ProtaxModel` with beta, sc_mean, sc_var.
+        segnum (int): Number of unique segment ids (for JIT compilation).
+        N (int): Number of nodes in the taxonomy (for JIT compilation).
 
     Returns:
-        A 1D jax array of length N with total probabilities per node.
+        jax.Array: A 1D array of length N with total probabilities per node.
+            These are P(node | query), unnormalized across levels but normalized
+            within each parent's children.
+
+    Note:
+        For deep taxonomies or many classifications, prefer `get_log_probs` to
+        avoid numerical underflow. Can be JIT-compiled by uncommenting the decorator.
     """
     X = get_X(q, ok, tree, N, params.sc_mean, params.sc_var)
     bprobs = fill_bprob(X, params.beta, tree, segnum)

--- a/protax/model.py
+++ b/protax/model.py
@@ -9,8 +9,20 @@ from .ops import knn, knn_v2
 # @jax.jit
 def seq_dist(q, seqs, ok, ok_query):
     """
-    Computes sequence distance between the query and 
-    an array of reference sequences
+    Compute Hamming-like distance between one query and many references.
+
+    Distances are computed as 1 - matches/valid where `valid` counts positions
+    that are valid in both the query and each reference. Bits are packed; A/T/G/C
+    bits are compared via bitwise operations.
+
+    Args:
+        q: Packed bits array for the query sequence bases (A/T/G/C), shape (D',).
+        seqs: Packed bits for reference sequences, shape (R, D').
+        ok: Packed bits mask of valid positions for references, shape (R, D').
+        ok_query: Packed bits mask of valid positions for the query, shape (D',).
+
+    Returns:
+        A 1D jax array of distances for each reference, shape (R,).
     """
 
     # count matches and valid positions
@@ -24,10 +36,14 @@ def seq_dist(q, seqs, ok, ok_query):
 
 def seq_dist2(s1, s2):
     """
-    Alternative cleaner seqdist implementation
+    Alternative distance using explicit one-hot with validity channel.
 
-    s1: (5, d) one-hot sequence
-    s2: (5, d) one-hot sequence
+    Args:
+        s1: One-hot with validity, shape (5, D) where last row is valid mask.
+        s2: One-hot with validity, shape (5, D) where last row is valid mask.
+
+    Returns:
+        Scalar fraction of matches over valid positions.
     """
     intersect = jnp.bitwise_and(s1, s2)
     matches = jax.lax.population_count(intersect, axis=1)
@@ -39,7 +55,21 @@ def seq_dist2(s1, s2):
 
 def get_X(q, ok_q, tree, N, sc_mean, sc_var):
     """
-    KNN-based method for computing design matrix
+    Construct the PROTAX design matrix using KNN distances and node state.
+
+    The design matrix concatenates binary node state features and KNN-derived
+    distance features normalized by per-level scaling parameters.
+
+    Args:
+        q: Packed bits for the query sequence bases (A/T/G/C).
+        ok_q: Packed bits mask for valid query positions.
+        tree: `TaxTree` instance with references, node2seq, and node_state.
+        N: Number of taxonomy nodes.
+        sc_mean: (N, 2) scaling means per node and distance column.
+        sc_var: (N, 2) scaling variances per node and distance column.
+
+    Returns:
+        A jax array of shape (N, M) where M = node_state_cols + 2.
     """
 
     node2seq = tree.node2seq
@@ -57,7 +87,14 @@ def get_X(q, ok_q, tree, N, sc_mean, sc_var):
 
 def get_z(X, params):
     """
-    Compute weighted sum for each node
+    Compute per-node linear score z = X · beta.
+
+    Args:
+        X: Design matrix of shape (N, M).
+        params: `ProtaxModel` containing `beta` with shape (N, M).
+
+    Returns:
+        A 1D jax array z of length N.
     """
     z = jnp.sum(jnp.multiply(X, params.beta), axis=1)
     return z
@@ -65,7 +102,15 @@ def get_z(X, params):
 
 def get_bprobs(z, segments, segnum):
     """
-    Compute branch probabilities of each node
+    Compute normalized branch probabilities per parent segment.
+
+    Args:
+        z: Nonnegative scores per node, shape (N,).
+        segments: Segment id (parent id bucket) per node, shape (N,).
+        segnum: Number of unique segment ids.
+
+    Returns:
+        A jax array of branch probabilities per node, shape (N,).
     """
     norm_factors = jax.ops.segment_sum(z, segments, num_segments=segnum, indices_are_sorted=True)
     norm_factors = jnp.take(norm_factors, segments, indices_are_sorted=True)
@@ -78,8 +123,17 @@ def get_bprobs(z, segments, segnum):
 
 def get_log_bprobs(z, segments, segnum):
     """
-    Compute log branch probabilities of each node
-    For training PROTAX
+    Compute log-branch probabilities per node in a numerically stable way.
+
+    Useful for training and for accumulating log-probabilities along paths.
+
+    Args:
+        z: Real-valued scores per node, shape (N,).
+        segments: Segment id (parent id bucket) per node, shape (N,).
+        segnum: Number of unique segment ids.
+
+    Returns:
+        A jax array of log-branch probabilities per node, shape (N,).
     """
 
     exp_z = jnp.exp(z)
@@ -93,13 +147,17 @@ def get_log_bprobs(z, segments, segnum):
 
 def fill_bprob(X, beta, tree, segnum):
     """
-    Compute branch probability of entire taxonomy, filled in relevant paths
-    X: design matrix of shape [N, M]
-    beta: param matrix of shape [N, M]
-    parents: array with shape [N]
+    Compute per-level path-wise branch probabilities across the taxonomy.
 
-    N = # nodes
-    M = # features
+    Args:
+        X: Design matrix, shape (N, M).
+        beta: Parameter matrix, shape (N, M).
+        tree: `TaxTree` with segments, paths, node_state, and priors.
+        segnum: Number of unique segment ids.
+
+    Returns:
+        A jax array of shape (L, P) with per-level branch probabilities along
+        each path in `tree.paths` (L levels by P paths).
     """
     z = jnp.sum(jnp.multiply(X, beta), axis=1)
     max_z = jax.ops.segment_max(z, tree.segments, num_segments=segnum, indices_are_sorted=True)
@@ -114,8 +172,17 @@ def fill_bprob(X, beta, tree, segnum):
 
 def fill_log_bprob(X, beta, tree, segnum):
     """
-    Compute log probabilities over entire taxonomy
-    Used for training PROTAX
+    Compute per-level log-branch probabilities across the taxonomy.
+
+    Args:
+        X: Design matrix, shape (N, M).
+        beta: Parameter matrix, shape (N, M).
+        tree: `TaxTree` with segments and paths.
+        segnum: Number of unique segment ids.
+
+    Returns:
+        A jax array of shape (L, P) with per-level log-branch probabilities
+        along each path in `tree.paths`.
     """
     z = jnp.sum(jnp.multiply(X, beta), axis=1)
     max_z = jax.ops.segment_max(z, tree.segments, num_segments=segnum, indices_are_sorted=True)
@@ -132,7 +199,18 @@ def fill_log_bprob(X, beta, tree, segnum):
 # @partial(jax.jit, static_argnums=(4, 5))
 def get_log_probs(q, ok, tree, params, segnum, N):
     """
-    Compute log probabilities for each node
+    Compute log-probability of each node by summing log-branch probs per path.
+
+    Args:
+        q: Packed bits for query bases.
+        ok: Packed bits mask for valid query positions.
+        tree: `TaxTree` instance.
+        params: `ProtaxModel` with beta, sc_mean, sc_var.
+        segnum: Number of unique segment ids.
+        N: Number of nodes in the taxonomy.
+
+    Returns:
+        A 1D jax array of length N with total log-probabilities per node.
     """
     X = get_X(q, ok, tree, N, params.sc_mean, params.sc_var)
     bprobs = fill_log_bprob(X, params.beta, tree, segnum)
@@ -140,6 +218,20 @@ def get_log_probs(q, ok, tree, params, segnum, N):
 
 # @partial(jax.jit, static_argnums=(4, 5))
 def get_probs(q, ok, tree, params, segnum, N):
+    """
+    Compute probability of each node by multiplying branch probs per path.
+
+    Args:
+        q: Packed bits for query bases.
+        ok: Packed bits mask for valid query positions.
+        tree: `TaxTree` instance.
+        params: `ProtaxModel` with beta, sc_mean, sc_var.
+        segnum: Number of unique segment ids.
+        N: Number of nodes in the taxonomy.
+
+    Returns:
+        A 1D jax array of length N with total probabilities per node.
+    """
     X = get_X(q, ok, tree, N, params.sc_mean, params.sc_var)
     bprobs = fill_bprob(X, params.beta, tree, segnum)
     return jnp.prod(bprobs, axis=1)

--- a/protax/ops/__init__.py
+++ b/protax/ops/__init__.py
@@ -1,3 +1,22 @@
+"""
+Custom JAX operations for PROTAX-GPU.
+
+This subpackage provides custom CPU and GPU implementations of operations
+that are critical for PROTAX performance, particularly k-nearest neighbor
+search on sparse matrices.
+
+The operations are implemented as:
+- C++ code for CPU execution (cpu_ops)
+- CUDA kernels for GPU execution (gpu_ops)
+- JAX primitives with MLIR lowering rules (knn_register)
+
+Main exports:
+    knn: K-nearest neighbor search (k=2) with automatic CPU/GPU dispatch
+    knn_v2: GPU-only KNN variant with optimized kernel
+
+Note:
+    GPU operations are optional and will be unavailable if CUDA is not present.
+"""
 from . import cpu_ops
 try:
     from . import gpu_ops

--- a/protax/ops/knn_register.py
+++ b/protax/ops/knn_register.py
@@ -31,7 +31,25 @@ except ImportError:
 # =======================================================
 def default_layouts(*shapes):
     """
-    Helper to specify default memory layout for custom call
+    Generate default row-major memory layouts for custom call operands/results.
+
+    XLA custom calls require explicit memory layout specifications. This helper
+    generates the standard row-major layout (last dimension varies fastest) for
+    tensors of given shapes.
+
+    Args:
+        *shapes (tuple of tuple): Variable number of shape tuples, e.g.
+            (10, 20), (5, 3, 4) for 2D and 3D arrays.
+
+    Returns:
+        list of range: List of dimension orderings where each range specifies
+            row-major layout (dimensions in reverse order).
+
+    Example:
+        >>> default_layouts((3, 4), (5,))
+        [range(1, -1, -1), range(0, -1, -1)]
+        # For (3,4): dims [1,0] means last dim varies fastest (row-major)
+        # For (5,):   dims [0] means single dimension
     """
     return [range(len(shape) - 1, -1, -1) for shape in shapes]
 
@@ -43,7 +61,34 @@ def default_layouts(*shapes):
 
 def knn(indptr, indices, matdat, N):
     """
-    Return row-wise k nearest neighbors for a sparse CSR matrix
+    Compute row-wise k=2 nearest neighbors for a sparse CSR matrix.
+
+    For each row, identifies the two smallest values and returns them. This is
+    used in PROTAX to find the k=2 nearest reference sequences per taxonomic node.
+
+    Args:
+        indptr (jax.Array): CSR row pointer array, shape (N+1,). Entry i gives
+            the start index in `indices`/`matdat` for row i.
+        indices (jax.Array): CSR column indices, shape (nnz,).
+        matdat (jax.Array): CSR data values (e.g., distances), shape (nnz,).
+            Must be float32.
+        N (int): Number of rows in the matrix.
+
+    Returns:
+        jax.Array: Shape (N, 2) containing the k=2 smallest values per row.
+            Rows with fewer than 2 elements are zero-padded.
+
+    Note:
+        Automatically dispatches to CPU or GPU implementation based on the
+        default backend. For GPU-only execution, use `knn_v2`.
+
+    Example:
+        >>> indptr = jnp.array([0, 2, 5])  # 2 rows
+        >>> indices = jnp.array([0, 2, 1, 3, 4])
+        >>> matdat = jnp.array([0.1, 0.5, 0.2, 0.3, 0.4], dtype=jnp.float32)
+        >>> knn(indptr, indices, matdat, 2)
+        Array([[0.1, 0.5],
+               [0.2, 0.3]], dtype=float32)
     """
 
     res = jnp.zeros((N, 2))
@@ -52,7 +97,25 @@ def knn(indptr, indices, matdat, N):
 
 def knn_v2(indptr, indices, matdat, N):
     """
-    Return row-wise k nearest neighbors for a sparse CSR matrix
+    GPU-only variant of KNN with optimized kernel.
+
+    Similar to `knn` but uses an alternative CUDA kernel implementation that
+    may have different performance characteristics. Only works on GPU.
+
+    Args:
+        indptr (jax.Array): CSR row pointer array, shape (N+1,).
+        indices (jax.Array): CSR column indices, shape (nnz,).
+        matdat (jax.Array): CSR data values, shape (nnz,). Must be float32.
+        N (int): Number of rows in the matrix.
+
+    Returns:
+        jax.Array: Shape (N, 2) containing the k=2 smallest values per row.
+
+    Raises:
+        ValueError: If GPU operations are not available.
+
+    Note:
+        This function requires CUDA and will fail if GPU ops are not compiled.
     """
 
     res = jnp.zeros((N, 2))
@@ -64,21 +127,52 @@ def knn_v2(indptr, indices, matdat, N):
 # =======================================================
 def _knn_abstract_eval(indptr, indices, matdat, res):
     """
-    Abstract evaluation for knn primitive where k=2
+    Abstract evaluation for knn primitive (shape and dtype inference).
 
-    mat: input CSR matrix
+    JAX's JIT compiler calls this during trace to determine output shapes and
+    dtypes without executing the operation. This enables static compilation.
 
-    NOTE: signature should match that of _knn_prim.bind() call
+    Args:
+        indptr: Abstract value for CSR row pointers.
+        indices: Abstract value for CSR column indices.
+        matdat: Abstract value for CSR data (determines output dtype).
+        res: Abstract value for result template (determines output shape).
+
+    Returns:
+        ShapedArray: Abstract array with shape (N, 2) and dtype matching `matdat`.
+
+    Note:
+        Signature must match `_knn_prim.bind()` call signature exactly.
     """
     return ShapedArray(res.shape, matdat.dtype)
 
 
 def _knn_lowering(ctx, indptr, indices, matdat, res, platform="cpu"):
     """
-    MLIR lowering rule for knn primitive where k=2.
-    i.e. lowering knn primitive to MLIR custom call
+    MLIR lowering rule for knn primitive (compilation to custom call).
 
-    ctx: mlir.LoweringRuleContext
+    This function is called by JAX's compiler to convert the abstract `knn`
+    primitive into concrete MLIR custom_call operations that invoke C++/CUDA
+    implementations.
+
+    Args:
+        ctx (mlir.LoweringRuleContext): Context containing input abstract values
+            and MLIR builder state.
+        indptr: MLIR value for CSR row pointers.
+        indices: MLIR value for CSR column indices.
+        matdat: MLIR value for CSR data.
+        res: MLIR value for result template.
+        platform (str): Target platform, either "cpu" or "gpu".
+
+    Returns:
+        list: Single-element list containing MLIR value for the result tensor.
+
+    Raises:
+        NotImplementedError: If dtype is not float32.
+
+    Note:
+        GPU version uses an opaque descriptor to pass problem size to CUDA kernel.
+        CPU version passes N as a scalar constant operand.
     """
 
     mat_dtype = ctx.avals_in[2].dtype
@@ -128,21 +222,49 @@ def _knn_lowering(ctx, indptr, indices, matdat, res, platform="cpu"):
 # =======================================================
 def _knn_v2_abstract_eval(indptr, indices, matdat, res):
     """
-    Abstract evaluation for knn primitive where k=2
+    Abstract evaluation for knn_v2 primitive (GPU variant).
 
-    mat: input CSR matrix
+    Identical to `_knn_abstract_eval` but for the knn_v2 primitive.
 
-    NOTE: signature should match that of _knn_prim.bind() call
+    Args:
+        indptr: Abstract value for CSR row pointers.
+        indices: Abstract value for CSR column indices.
+        matdat: Abstract value for CSR data (determines output dtype).
+        res: Abstract value for result template (determines output shape).
+
+    Returns:
+        ShapedArray: Abstract array with shape (N, 2) and dtype matching `matdat`.
+
+    Note:
+        Signature must match `_knn_v2_prim.bind()` call signature exactly.
     """
     return ShapedArray(res.shape, matdat.dtype)
 
 
 def _knn_v2_lowering(ctx, indptr, indices, matdat, res):
     """
-    MLIR lowering for knn primitive where k=2.
-    i.e. lowering primitive to MLIR custom call (knn kernel dispatch)
+    MLIR lowering for knn_v2 primitive (GPU-only variant).
 
-    ctx: mlir.LoweringRuleContext
+    Similar to `_knn_lowering` but specifically for the GPU-optimized v2 kernel.
+    Raises an error if GPU operations are not available.
+
+    Args:
+        ctx (mlir.LoweringRuleContext): Context containing input abstract values.
+        indptr: MLIR value for CSR row pointers.
+        indices: MLIR value for CSR column indices.
+        matdat: MLIR value for CSR data.
+        res: MLIR value for result template.
+
+    Returns:
+        list: Single-element list containing MLIR value for the result tensor.
+
+    Raises:
+        NotImplementedError: If dtype is not float32.
+        ValueError: If GPU operations are not compiled/available.
+
+    Note:
+        This variant calls a different CUDA kernel (gpu_knn_v2_f32) that may
+        use alternative optimization strategies.
     """
 
     mat_dtype = ctx.avals_in[2].dtype

--- a/protax/protax_utils.py
+++ b/protax/protax_utils.py
@@ -13,7 +13,16 @@ from pathlib import Path
 
 def read_params(pdir):
     """
-    Read parameters from file
+    Read parameter matrix from a plaintext file into a list of jax arrays.
+
+    The file is expected to contain whitespace-separated float values per line
+    for each model level; lines are parsed into arrays via `jnp.fromstring`.
+
+    Args:
+        pdir: Path to the parameter file, typically `model.pars`.
+
+    Returns:
+        A list of jax arrays, one per line.
     """
     print("reading parameters")
     
@@ -26,7 +35,17 @@ def read_params(pdir):
 
 def read_scalings(pdir):
     """
-    Read scalings from file
+    Read scaling statistics from a plaintext file into a numpy array.
+
+    The file is expected to contain tokens like `mean <value> var <value>` per
+    row; this function extracts alternating values into a float32 array
+    shaped (levels, 4), later split into mean/var per distance feature.
+
+    Args:
+        pdir: Path to the scalings file, typically `model.scs`.
+
+    Returns:
+        A numpy array of shape (L, 4) with scaling stats.
     """
     print("reading scalings")
     f = open(pdir)
@@ -40,7 +59,22 @@ def read_scalings(pdir):
 
 def read_taxonomy(tdir):
     """
-    Read taxonomy tree from file
+    Read a PROTAX taxonomy description and build core arrays.
+
+    The input is a tab-separated file `taxonomy.priors` with columns
+    `(nid, pid, lvl, name, prior, ...)`. This returns:
+    - segments: parent ids per node mapped to compact segment ids (for JAX segment ops)
+    - unks: boolean flag for unknown nodes
+    - layers: integer taxonomic level per node
+    - priors: prior probability mass per node
+    - descendants: per-node path indices to ancestors across levels
+    - parents: raw parent nid per node
+
+    Args:
+        tdir: Path to `taxonomy.priors`.
+
+    Returns:
+        Tuple of numpy arrays `(segments, unks, layers, priors, descendants, parents)`.
     """
     print("reading taxonomy file")
     f = open(tdir)
@@ -86,7 +120,20 @@ def read_taxonomy(tdir):
 
 def get_descendants(nodes, N, layers):
     """
-    Get the descendant nodes for each entry in a node-parent vector
+    Compute, for each node, the ancestor path indices across taxonomic levels.
+
+    NOTE: This implementation assumes reverse-topological ordering and uses a
+    fixed width of 8 for levels; it may need adjustments if the number of
+    ranks differs.
+
+    Args:
+        nodes: Parent nid per node, shape (N,).
+        N: Total number of nodes.
+        layers: Layer index per node, shape (N,).
+
+    Returns:
+        A numpy int array of shape (N, 8) where each row stores the nid of
+        the ancestor at a given layer index for that node.
     """
 
     # TODO fix this
@@ -109,7 +156,16 @@ def get_descendants(nodes, N, layers):
 
 def read_refs(ref_dir):
     """
-    Read reference sequences from file
+    Read reference sequences in alignment format and pack to bits.
+
+    The file is read in pairs of lines: header then sequence. Sequences are
+    converted to packed bits arrays for A/T/G/C and a validity mask.
+
+    Args:
+        ref_dir: Path to `refs.aln` or an equivalent two-line FASTA-like file.
+
+    Returns:
+        Tuple `(refs, ok_pos)` of numpy uint8 arrays containing packed bits.
     """
     print("reading reference sequences")
     f = open(ref_dir)
@@ -133,7 +189,14 @@ def read_refs(ref_dir):
 
 def assign_refs(seq2tax_dir):
     """
-    Assign reference sequences to nodes from file
+    Build a sparse mapping from nodes to reference sequence indices.
+
+    Args:
+        seq2tax_dir: Path to `model.rseqs.numeric` describing node-to-refs.
+
+    Returns:
+        Tuple `(nids, seqs)` of integer arrays listing node ids and matching
+        reference ids suitable for constructing a CSR matrix.
     """
     # TODO make a processing script for easier reading on next runs
     print("\nassigning reference sequences to taxa")
@@ -155,7 +218,14 @@ def assign_refs(seq2tax_dir):
 
 def get_seq_bits(seq_str):
     """
-    Convert seqence string to bit representation
+    Convert a sequence string into boolean bit planes for A/T/G/C and validity.
+
+    Args:
+        seq_str: String of characters from {A,T,G,C,-} (or other ambiguous).
+
+    Returns:
+        A numpy boolean array of shape (5, L) where rows 0-3 are A/T/G/C and
+        row 4 is a validity mask (any of A/T/G/C).
     """
     seq_chars = np.frombuffer(seq_str.encode('ascii'), np.int8)
     a = seq_chars == 65
@@ -170,14 +240,29 @@ def get_seq_bits(seq_str):
 
 def assign_params(beta, sc, lvl):
     """
-    Assign parameters to each node given the levels each node is in
+    Broadcast per-level parameters to per-node arrays via layer index.
+
+    Args:
+        beta: Parameter matrix per level, shape (L, M).
+        sc: Scaling statistics per level, shape (L, 4).
+        lvl: Layer index per node, shape (N,).
+
+    Returns:
+        Tuple `(beta_node, sc_node)` where shapes are (N, M) and (N, 4).
     """
     return np.take(beta, lvl-1, axis=0), np.take(sc, lvl-1, axis=0)
 
 
 def convert_model(model_dir, savedir="models/params"):
     """
-    Read and convert model files stored in model_dir, convert and save them to npz
+    Convert plaintext PROTAX model files into a compressed `.npz` archive.
+
+    Reads `model.pars` and `model.scs` from `model_dir` and writes
+    `model.npz` into `savedir` (with numeric suffixes if the file exists).
+
+    Args:
+        model_dir: Directory containing `model.pars` and `model.scs`.
+        savedir: Output directory for the converted `.npz` file.
     """
     mdir = Path(model_dir)
     savedir = Path(savedir)
@@ -205,7 +290,15 @@ def convert_model(model_dir, savedir="models/params"):
 
 def convert_taxonomy(treedir, savedir="models/ref_db"):
     """
-    Read model files stored in treedir, convert and save them to a npz
+    Convert taxonomy files into a compressed `.npz` archive for JAX.
+
+    Reads `taxonomy.priors`, `refs.aln`, and `model.rseqs.numeric` from
+    `treedir`, computes node state and mappings, and writes `taxonomy.npz` to
+    `savedir` (with numeric suffixes if needed).
+
+    Args:
+        treedir: Directory containing taxonomy inputs.
+        savedir: Output directory for the converted `.npz` file.
     """
 
     treedir = Path(treedir)
@@ -254,6 +347,16 @@ def convert_taxonomy(treedir, savedir="models/ref_db"):
 
 
 def read_baseline(model_dir=r"/h/royga/Documents/PROTAX-dsets/30k_small"):
+    """
+    Load a minimal baseline representation for nearest-neighbor classification.
+
+    Args:
+        model_dir: Directory containing a `model.npz` with taxonomy arrays.
+
+    Returns:
+        Tuple `(refs, ok_pos, n2s, paths)` where `n2s` is a CSR matrix mapping
+        nodes to sequences.
+    """
     loaded = np.load(model_dir + r'/model.npz')
     refs = jnp.array(loaded['refs'])
     seg = loaded['segments']
@@ -269,7 +372,16 @@ def read_baseline(model_dir=r"/h/royga/Documents/PROTAX-dsets/30k_small"):
 
 def read_model_jax(par_dir, tax_dir):
     """
-    Read model npz representation
+    Load model and taxonomy from `.npz` archives into JAX-friendly structures.
+
+    Args:
+        par_dir: Path to `model.npz` containing `beta` and `scalings`.
+        tax_dir: Path to `taxonomy*.npz` containing refs, ok_pos, segments, etc.
+
+    Returns:
+        Tuple `(tree, params, N, segnum)` where `tree` is a `TaxTree`,
+        `params` is a `ProtaxModel`, `N` is number of nodes, and `segnum` is
+        the number of unique segments.
     """
     par_dir = Path(par_dir)
     tax_dir = Path(tax_dir)
@@ -331,7 +443,17 @@ def read_model_jax(par_dir, tax_dir):
 
 def get_train_targets(seq2tax_dir, layers, R):
     """
-    Save target NIDs for each reference sequence contained in R. Save as CSV
+    Compute per-reference target node ids at the lowest available level.
+
+    The output is written to `30k-targets.csv` for downstream training.
+
+    Args:
+        seq2tax_dir: Path to file mapping nodes to reference ids.
+        layers: Layer index per node, shape (N,).
+        R: Number of reference sequences.
+
+    Side Effects:
+        Writes a CSV file `30k-targets.csv` with targets per level.
     """
     f = open(seq2tax_dir)
 
@@ -352,12 +474,29 @@ def get_train_targets(seq2tax_dir, layers, R):
 
 
 def read_query(q):
+    """
+    Convert a single sequence string into packed bits arrays for JAX.
+
+    Args:
+        q: Sequence string.
+
+    Returns:
+        Tuple `(packed_bases, packed_ok)` as jax arrays of dtype uint8.
+    """
     s = get_seq_bits(q)
     return jnp.array(np.packbits(s[:4], axis=None)), jnp.array(np.packbits(s[4], axis=None))
 
 
 def str2batch_query(q):
+    """
+    Batch-convert multiple sequence strings into packed bits arrays.
 
+    Args:
+        q: Iterable of sequence strings.
+
+    Returns:
+        Tuple `(queries, ok_pos)` both jax arrays with packed bits.
+    """
     queries = []
     ok_pos = []
     for i in q:

--- a/protax/taxonomy.py
+++ b/protax/taxonomy.py
@@ -10,21 +10,16 @@ class CSRWrapper(NamedTuple):
 
 class TaxTree(NamedTuple):
     """
-    State of the taxonomic tree
+    Container for taxonomy state and reference data used by PROTAX.
 
-    N = total number of nodes
-    L = Number of non-species nodes (i.e nodes with depth < 7)
-    R = total number of reference sequences
-
-    refs: All reference sequences
-    ok_pos: positions which contain a, t, c, g
-    node_refs: reference sequences belong to node at the same index
-    layer: boundary indices of each layer
-    prior: prior probability of each node
-    prob: predicted probability of each node
-    children: adjacency matrix of each node
-    descendants: descendants of each node
-    unk: Whether the node at this index represents an unknown species or not
+    Fields:
+        refs: Packed-bit reference sequences, shape [R, D'].
+        ok_pos: Packed-bit valid-position masks for references, shape [R, D'].
+        segments: Parent segment id per node for segment-wise reductions, [N].
+        node2seq: Sparse mapping from nodes to reference indices (CSR-like).
+        paths: For each node, a path index per level, used to aggregate probs.
+        node_state: Binary indicators per node (e.g., empty-but-known, has-refs).
+        prior: Prior probability mass per node.
     """
     refs: jax.Array                  # [R, 5]
     ok_pos: jax.Array                # [R]
@@ -37,7 +32,12 @@ class TaxTree(NamedTuple):
 
 class ProtaxModel(NamedTuple):
     """
-    Contains parameters for PROTAX model
+    Model parameters and scaling statistics for PROTAX inference/training.
+
+    Fields:
+        beta: Per-node parameter matrix aligned with design matrix columns.
+        sc_mean: Per-node scaling means for distance features.
+        sc_var: Per-node scaling variances for distance features.
     """
     
     beta: jax.Array

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -15,6 +15,9 @@ TEST_QUERY = '---------------------------GCTGGTATAGTAGGAACATCTTTA---AGAATTTTAATT
 
 # ===== Helper functions =====
 def valid_path(dir):
+    """
+    Argparse path validator that ensures the given path exists.
+    """
     dir = Path(dir)
     if not dir.exists():
         raise argparse.ArgumentTypeError(f"{dir} is not a valid path")
@@ -24,7 +27,14 @@ def valid_path(dir):
 
 def lil_to_csr(lil, shape):
     """
-    Converts a list of lists to a csr matrix
+    Convert a Python list-of-lists of column indices to a CSR matrix.
+
+    Args:
+        lil: List where `lil[i]` contains column indices for row i.
+        shape: Target matrix shape (rows, cols).
+
+    Returns:
+        A SciPy CSR matrix with boolean data.
     """
 
     num_nonzero = 0
@@ -47,7 +57,7 @@ def lil_to_csr(lil, shape):
 
 def add_unknown_nodes(df):
     """
-    Adds unknown nodes to the taxonomy
+    Append sibling "unknown" nodes for each unique parent in the taxonomy.
     """
     parents = df["parentid"].unique() 
     nid = df.index.max() + 1
@@ -66,7 +76,7 @@ def add_unknown_nodes(df):
 
 def add_prior(df):
     """
-    Adds uniform prior over leaves to the taxonomy.
+    Compute and attach a uniform prior mass distributed over leaf nodes.
     """
     print("start adding prior")
     parents = df["parentid"].unique() 
@@ -92,9 +102,8 @@ def add_prior(df):
 
 
 def trim_subtaxa(df, keep):
-    """ 
-    Remove subtaxa from taxonomy specified in <keep>.
-    parents inherit subtaxa's children
+    """
+    Remove taxa whose rank is not in `keep`, reattaching children to kept parents.
     """
     print("start trimming subtaxa")
     ranks = dict(zip(df.index, df["rank"]))
@@ -130,6 +139,9 @@ def trim_subtaxa(df, keep):
     print("\nfinished trimming subtaxa")
 
 def convert_tsv(t_dir):
+    """
+    Convert a taxonomy TSV into PROTAX arrays and an intermediate NPZ file.
+    """
 
     # TODO change get_descendants to work with root being excluded
     df = pd.read_csv(t_dir, sep='\t')
@@ -178,6 +190,9 @@ def convert_tsv(t_dir):
 
 
 def assign_tax(ref_dir):
+    """
+    Assign reference sequences to taxa names to build node2seq and arrays.
+    """
     # TODO: temporary hardcoded funct to prevent processing again when debugging
     tax = np.load("temp_tax.npz", allow_pickle=True)
     names = tax["names"]
@@ -254,7 +269,7 @@ def assign_tax(ref_dir):
 
 def convert_sequences(ref_dir):
     """
-    converts reference sequences in tsv format to protax format
+    Convert a TSV file of sequences into packed-bit arrays for PROTAX.
     """
 
     # TODO remove hardcoded values
@@ -297,7 +312,7 @@ def convert_sequences(ref_dir):
 
 def read_jax_model(model_dir):
     """
-    Reads model files from JAX implementation of PROTAX
+    Load a small test model/taxonomy stored by earlier conversion helpers.
     """
     tax_npz = np.load("8M_tax.npz", allow_pickle=True)
     

--- a/scripts/process_seqs.py
+++ b/scripts/process_seqs.py
@@ -1,3 +1,25 @@
+"""
+Command-line script for classifying DNA barcode sequences using PROTAX-GPU.
+
+This script provides a simple command-line interface to the PROTAX-GPU classifier.
+It reads query sequences from a FASTA-like alignment file and classifies them using
+a pre-trained model and reference database, writing results to CSV.
+
+Usage:
+    python scripts/process_seqs.py QUERY_FILE MODEL_FILE TAXONOMY_FILE
+
+Arguments:
+    QUERY_FILE: Path to query sequences (e.g., refs.aln) in two-line format
+    MODEL_FILE: Path to trained model parameters (e.g., models/params/model.npz)
+    TAXONOMY_FILE: Path to taxonomy database (e.g., models/ref_db/taxonomy37k.npz)
+
+Example:
+    python scripts/process_seqs.py data/queries.aln models/params/model.npz \\
+        models/ref_db/taxonomy37k.npz
+
+Output:
+    Results are written to pyprotax_results.csv in the current directory.
+"""
 from protax.classify import classify_file
 import sys
 

--- a/scripts/train_gd.py
+++ b/scripts/train_gd.py
@@ -1,3 +1,33 @@
+"""
+Training script for PROTAX-GPU using gradient descent.
+
+This script implements training of PROTAX model parameters (beta coefficients)
+using stochastic gradient descent on self-classification of reference sequences.
+The training process uses leave-one-out cross-validation where each reference
+is temporarily removed from the database and used as a query.
+
+The script supports:
+- Minibatch gradient descent with configurable batch size
+- Cross-entropy loss optimization
+- Automatic differentiation via JAX
+- Model checkpointing
+
+Usage:
+    python scripts/train_gd.py --train_dir PATH_TO_REFS --targ_dir PATH_TO_TARGETS
+
+Arguments:
+    --train_dir: Path to reference alignment file (e.g., refs.aln)
+    --targ_dir: Path to CSV file with per-reference target node IDs
+
+Configuration:
+    Training hyperparameters are defined in the `tc` dictionary:
+    - learning_rate: Step size for gradient updates (default: 0.001)
+    - batch_size: Number of samples per batch (default: 500)
+    - num_epochs: Number of passes through the dataset (default: 30)
+
+Output:
+    Trained model is saved to models/params/m2.npz
+"""
 import protax.model as model
 from protax import protax_utils
 from protax.taxonomy import CSRWrapper
@@ -22,31 +52,46 @@ def CE_loss(log_probs, y_ind):
     """
     Cross-entropy loss for selected targets from per-node log-probabilities.
 
+    Computes the negative log-likelihood of the target nodes given the model's
+    probability distribution. Used as the optimization objective during training.
+
     Args:
-        log_probs: Log-branch probabilities (levels by paths) or log-probs
-            indexed such that gathering by `y_ind` yields the per-sample terms.
-        y_ind: Integer target indices for each sample.
+        log_probs (jax.Array): Log-branch probabilities organized as (levels, paths)
+            or flattened per-node log-probabilities, shape compatible with indexing
+            by y_ind.
+        y_ind (jax.Array): Integer indices of target nodes for each sample in the
+            batch.
 
     Returns:
-        Scalar negative log-likelihood for the batch.
+        jax.Array: Scalar negative log-likelihood summed over the batch. Lower
+            values indicate better fit to targets.
     """
     return -jnp.sum(jnp.take(log_probs, y_ind, axis=0))
 
 
 def forward(q, ok, tree, beta, sc_mean, sc_var, N, segnum, y_ind, lvl):
     """
-    Forward pass: build design matrix, compute log-branch probs, CE loss.
+    Forward pass: build design matrix, compute log-branch probs, and CE loss.
+
+    This function executes the full PROTAX forward pass from query sequence to
+    loss value. It is the main function that gets differentiated by JAX to compute
+    gradients with respect to beta.
 
     Args:
-        q, ok: Packed bits query and validity.
-        tree: `TaxTree`.
-        beta, sc_mean, sc_var: Parameters or stats.
-        N, segnum: Taxonomy sizes.
-        y_ind: Target node index.
-        lvl: Per-node level index used to broadcast beta per level.
+        q (jax.Array): Packed bits query sequence.
+        ok (jax.Array): Packed bits validity mask for query.
+        tree (TaxTree): Taxonomy tree structure.
+        beta (jax.Array): Parameter matrix per level, shape (num_levels, num_features).
+            Will be broadcast to per-node using `lvl`.
+        sc_mean (jax.Array): Per-node scaling means.
+        sc_var (jax.Array): Per-node scaling variances.
+        N (int): Number of nodes in taxonomy.
+        segnum (int): Number of unique parent segments.
+        y_ind (jax.Array): Target node index for this sample.
+        lvl (jax.Array): Per-node level indices for broadcasting beta.
 
     Returns:
-        Scalar loss.
+        jax.Array: Scalar cross-entropy loss for this sample.
     """
     beta = jnp.take(beta, lvl, axis=0)
     X = model.get_X(q, ok, tree, N, sc_mean, sc_var)
@@ -60,7 +105,25 @@ forward_jit = jax.jit(forward, static_argnums=(6, 7))
 
 def get_targ(target_dir):
     """
-    Extract, per reference, the most specific (lowest-level) node id target.
+    Extract the most specific (lowest-level) node id target for each reference.
+
+    Reads a CSV file where rows are taxonomic levels and columns are references.
+    For each reference, finds the deepest level (finest taxonomic assignment) that
+    is not -1 (missing), and returns that node ID as the training target.
+
+    Args:
+        target_dir (str or Path): Path to CSV file with target node IDs.
+            Expected format: rows = levels, columns = references, values = node IDs
+            or -1 for missing assignments.
+
+    Returns:
+        jax.Array: 1D integer array of length R (number of references) containing
+            the target node ID for each reference, representing its finest taxonomic
+            assignment.
+
+    Example:
+        For a reference assigned to nodes [1, 5, 12, -1, -1, -1, -1] across 7 levels,
+        this returns 12 (the last non-missing assignment).
     """
     targ = pd.read_csv(target_dir)
     targ = targ.to_numpy()[:, 1:].T
@@ -81,7 +144,29 @@ def get_targ(target_dir):
 
 def mask_n2s(n2s, node_state, i):
     """
-    Remove one reference column from node2seq and update node_state accordingly.
+    Remove one reference from the database for leave-one-out cross-validation.
+
+    Masks out reference `i` from the node-to-sequence mapping and updates node
+    state indicators to reflect nodes that lost their only reference. This is
+    used during training to prevent references from being their own nearest
+    neighbors.
+
+    Args:
+        n2s (scipy.sparse.csr_matrix): Node-to-sequence mapping, shape (N, R)
+            where entry [node, ref] = 1 if ref is assigned to node.
+        node_state (numpy.ndarray): Binary node state indicators, shape (N, 1)
+            indicating empty-but-known nodes.
+        i (int): Index of reference to mask out.
+
+    Returns:
+        tuple: (masked_n2s, updated_node_state) where:
+            - masked_n2s (CSRWrapper): Updated mapping with reference i removed
+            - updated_node_state (jax.Array): Shape (N, 2) with columns:
+                [0] = empty-but-known, [1] = has-references
+
+    Note:
+        After masking, some nodes may become empty if reference `i` was their only
+        assigned sequence. The node_state is updated accordingly.
     """
     ref_mask = np.ones((n2s.shape[1],), dtype=np.int32)
     ref_mask[i] = 0
@@ -106,10 +191,24 @@ def mask_n2s(n2s, node_state, i):
 
 def load_params(pdir, tdir):
     """
-    Load raw parameters and layer indices from saved `.npz` archives.
+    Load raw parameters and layer indices from saved model archives.
+
+    Reads the initial model parameters (beta, scalings) and taxonomy metadata
+    (node layers) from .npz files. These serve as initialization for training.
+
+    Args:
+        pdir (str or Path): Path to parameter .npz file (e.g., models/params/model.npz).
+        tdir (str or Path): Path to taxonomy .npz file (e.g., models/ref_db/taxonomy*.npz).
 
     Returns:
-        Tuple `(beta, lvl, sc)`.
+        tuple: (beta, lvl, sc) where:
+            - beta (numpy.ndarray): Initial parameter matrix per level
+            - lvl (numpy.ndarray): Layer index for each node
+            - sc (numpy.ndarray): Scaling statistics (mean/var) per level
+
+    Note:
+        Beta is per-level and must be broadcast to per-node using `lvl` during
+        the forward pass.
     """
     par_dir = Path(pdir)
     tax_dir = Path(tdir)
@@ -129,12 +228,35 @@ def load_params(pdir, tdir):
 
 def train(train_config, train_dir, targ_dir):
     """
-    Train beta parameters via SGD on reference self-classification.
+    Train PROTAX beta parameters via stochastic gradient descent.
+
+    Uses leave-one-out self-classification of reference sequences as training
+    signal. Each reference is temporarily removed from the database, classified
+    against remaining references, and the model is updated to maximize the
+    probability of the correct taxonomic assignment.
 
     Args:
-        train_config: Dict with keys `learning_rate`, `batch_size`, `num_epochs`.
-        train_dir: Path to references alignment used for self-supervision.
-        targ_dir: Path to CSV of per-reference targets.
+        train_config (dict): Training configuration with keys:
+            - 'learning_rate' (float): Gradient descent step size
+            - 'batch_size' (int): Number of samples per gradient update
+            - 'num_epochs' (int): Number of passes through the dataset
+        train_dir (str or Path): Path to reference alignment file (e.g., refs.aln)
+            containing sequences to use for self-supervised training.
+        targ_dir (str or Path): Path to CSV file with per-reference target node IDs,
+            specifying the ground truth taxonomic assignment for each reference.
+
+    Returns:
+        None
+
+    Side Effects:
+        - Saves trained model to models/params/m2.npz after each epoch
+        - Displays loss curve plot at end of training (via matplotlib)
+        - Prints per-batch and per-epoch loss to stdout
+
+    Note:
+        The model is initialized with random weights for beta. Scaling statistics
+        (sc_mean, sc_var) are loaded from the base model and not trained.
+        Training uses JAX's automatic differentiation on the `forward` function.
     """
     tree, params, N, segnum = protax_utils.read_model_jax(
         "models/params/model.npz", "models/ref_db/taxonomy37k.npz"

--- a/scripts/train_gd.py
+++ b/scripts/train_gd.py
@@ -20,17 +20,34 @@ import argparse
 
 def CE_loss(log_probs, y_ind):
     """
-    Computes the cross-entropy loss between the log_probs and
-    labels y_ind.
+    Cross-entropy loss for selected targets from per-node log-probabilities.
 
     Args:
-        log_probs: Log probabilities returned by the model, shape (N, D)
-        y_ind: Integer array of true class indices, shape (N,)
+        log_probs: Log-branch probabilities (levels by paths) or log-probs
+            indexed such that gathering by `y_ind` yields the per-sample terms.
+        y_ind: Integer target indices for each sample.
+
+    Returns:
+        Scalar negative log-likelihood for the batch.
     """
     return -jnp.sum(jnp.take(log_probs, y_ind, axis=0))
 
 
 def forward(q, ok, tree, beta, sc_mean, sc_var, N, segnum, y_ind, lvl):
+    """
+    Forward pass: build design matrix, compute log-branch probs, CE loss.
+
+    Args:
+        q, ok: Packed bits query and validity.
+        tree: `TaxTree`.
+        beta, sc_mean, sc_var: Parameters or stats.
+        N, segnum: Taxonomy sizes.
+        y_ind: Target node index.
+        lvl: Per-node level index used to broadcast beta per level.
+
+    Returns:
+        Scalar loss.
+    """
     beta = jnp.take(beta, lvl, axis=0)
     X = model.get_X(q, ok, tree, N, sc_mean, sc_var)
     log_probs = model.fill_log_bprob(X, beta, tree, segnum)
@@ -43,7 +60,7 @@ forward_jit = jax.jit(forward, static_argnums=(6, 7))
 
 def get_targ(target_dir):
     """
-    Get node id for each reference sequence at lowest level
+    Extract, per reference, the most specific (lowest-level) node id target.
     """
     targ = pd.read_csv(target_dir)
     targ = targ.to_numpy()[:, 1:].T
@@ -64,7 +81,7 @@ def get_targ(target_dir):
 
 def mask_n2s(n2s, node_state, i):
     """
-    Remove a column in node2seq
+    Remove one reference column from node2seq and update node_state accordingly.
     """
     ref_mask = np.ones((n2s.shape[1],), dtype=np.int32)
     ref_mask[i] = 0
@@ -88,6 +105,12 @@ def mask_n2s(n2s, node_state, i):
 
 
 def load_params(pdir, tdir):
+    """
+    Load raw parameters and layer indices from saved `.npz` archives.
+
+    Returns:
+        Tuple `(beta, lvl, sc)`.
+    """
     par_dir = Path(pdir)
     tax_dir = Path(tdir)
 
@@ -105,6 +128,14 @@ def load_params(pdir, tdir):
 
 
 def train(train_config, train_dir, targ_dir):
+    """
+    Train beta parameters via SGD on reference self-classification.
+
+    Args:
+        train_config: Dict with keys `learning_rate`, `batch_size`, `num_epochs`.
+        train_dir: Path to references alignment used for self-supervision.
+        targ_dir: Path to CSV of per-reference targets.
+    """
     tree, params, N, segnum = protax_utils.read_model_jax(
         "models/params/model.npz", "models/ref_db/taxonomy37k.npz"
     )


### PR DESCRIPTION
## Summary
This PR adds comprehensive docstrings across all core PROTAX-GPU modules and scripts to enable better API documentation generation with Sphinx/ReadTheDocs in the next step. All docstrings follow **Google/NumPy style** and include detailed parameter descriptions, return values, and usage examples.

## Changes Made

### Core Modules 
- **`protax/__init__.py`**: Added module-level docstring with package overview and example
- **`protax/classify.py`**: Comprehensive docstrings for `classify_file()` and `classify()` functions
- **`protax/model.py`**: Detailed documentation for all probability computation functions
- **`protax/taxonomy.py`**: Enhanced docstrings for `TaxTree` and `ProtaxModel` data structures  
- **`protax/protax_utils.py`**: Complete documentation for I/O utilities and sequence processing
- **`protax/ops/knn_register.py`**: Technical details for GPU/CPU KNN operations
- **`protax/baseline.py`**: Added docstrings for baseline classifier
- **`protax/ops/__init__.py`**: Module-level docstring explaining custom CPU/GPU operations architecture

### Scripts
- **`scripts/train_gd.py`**: Complete documentation for training workflow
- **`scripts/process_seqs.py`**: Usage documentation for classification script
- **`scripts/convert.py`**: Documentation for data conversion utilities